### PR TITLE
Improve the performance of snapshot_vec::extend

### DIFF
--- a/src/snapshot_vec.rs
+++ b/src/snapshot_vec.rs
@@ -275,8 +275,12 @@ impl<D: SnapshotVecDelegate> Extend<D::Value> for SnapshotVec<D> {
     where
         T: IntoIterator<Item = D::Value>,
     {
-        for item in iterable {
-            self.push(item);
+        let initial_len = self.values.len();
+        self.values.extend(iterable);
+        let final_len = self.values.len();
+
+        if self.in_snapshot() {
+            self.undo_log.extend((initial_len..final_len).map(|len| NewElem(len)));
         }
     }
 }


### PR DESCRIPTION
Takes advantage of the much faster `Vec::extend` method.

In my simple benchmark: 
```
fn new_with_cap<T: Iterator<Item = usize>>(iter: T) -> SnapshotVec<usize> {
    let mut vec = SnapshotVec::with_capacity(100);
    vec.extend(iter);
    vec
}

fn new_wo_cap<T: Iterator<Item = usize>>(iter: T) -> SnapshotVec<usize> {
    let mut vec = SnapshotVec::new();
    vec.extend(iter);
    vec
}

#[bench]
fn bench_new_with_cap(b: &mut Bencher) {
    let n = test::black_box(100);
    b.iter(|| new_with_cap(0..n) )
}

#[bench]
fn bench_new_wo_cap(b: &mut Bencher) {
    let n = test::black_box(100);
    b.iter(|| new_wo_cap(0..n) )
}
```
for the following simple implementation:
```
impl SnapshotVecDelegate for usize {
    type Value = usize;
    type Undo = ();

    fn reverse(_: &mut Vec<usize>, _: ()) {}
}
```
I was able to get a decent speedup - the new variant is more than **4 times** faster for `SnapshotVec`s wtih known capacity and almost **10 times** faster for ones with undetermined capacity:
```
test bench_new_with_cap ... bench:          77 ns/iter (+/- 10)
test bench_new_wo_cap   ... bench:          79 ns/iter (+/- 2)
test bench_old_with_cap ... bench:         340 ns/iter (+/- 20)
test bench_old_wo_cap   ... bench:         774 ns/iter (+/- 32)
```