### PR TITLE
Add a `values_since_snapshot` method to `UnificationStore`

### DIFF
--- a/src/snapshot_vec.rs
+++ b/src/snapshot_vec.rs
@@ -61,7 +61,7 @@ impl<D> fmt::Debug for SnapshotVec<D>
 // Snapshots are tokens that should be created/consumed linearly.
 pub struct Snapshot {
     // Length of the undo log at the time the snapshot was taken.
-    length: usize,
+    pub(crate) length: usize,
 }
 
 pub trait SnapshotVecDelegate {


### PR DESCRIPTION
We'd like to abstract out the `vars_since_snapshot` methods for inference variables in rustc:
https://github.com/rust-lang/rust/blob/2a8f6a7806a9072fb5a5279a48bef316b749a433/src/librustc/infer/fudge.rs#L67-L72
At the moment, we can't get this information for an arbitrary `UnificationStore`, which means there are some awkward workarounds in the compiler.