### PR TITLE
Add a `vars_since_snapshot` method to `UnificationTable`

### DIFF
--- a/src/snapshot_vec.rs
+++ b/src/snapshot_vec.rs
@@ -60,6 +60,8 @@ impl<D> fmt::Debug for SnapshotVec<D>
 
 // Snapshots are tokens that should be created/consumed linearly.
 pub struct Snapshot {
+    // Number of values at the time the snapshot was taken.
+    pub(crate) value_count: usize,
     // Length of the undo log at the time the snapshot was taken.
     undo_len: usize,
 }
@@ -173,10 +175,9 @@ impl<D: SnapshotVecDelegate> SnapshotVec<D> {
     }
 
     pub fn start_snapshot(&mut self) -> Snapshot {
-        let length = self.undo_log.len();
         self.num_open_snapshots += 1;
-        Snapshot { length: length }
         Snapshot {
+            value_count: self.values.len(),
             undo_len: self.undo_log.len(),
         }
     }

--- a/src/unify/backing_vec.rs
+++ b/src/unify/backing_vec.rs
@@ -1,8 +1,7 @@
 #[cfg(feature = "persistent")]
 use dogged::DVec;
 use snapshot_vec as sv;
-use std::ops;
-use std::ops::RangeInclusive;
+use std::ops::{self, Range};
 use std::marker::PhantomData;
 
 use super::{VarValue, UnifyKey, UnifyValue};
@@ -31,8 +30,8 @@ pub trait UnificationStore:
 
     fn commit(&mut self, snapshot: Self::Snapshot);
 
-    fn values_since_snapshot(&mut self, snapshot: &Self::Snapshot) -> RangeInclusive<usize> {
-        snapshot.len()..=self.len()
+    fn values_since_snapshot(&self, snapshot: &Self::Snapshot) -> Range<usize> {
+        snapshot.len()..self.len()
     }
 
     fn reset_unifications(

--- a/src/unify/backing_vec.rs
+++ b/src/unify/backing_vec.rs
@@ -10,19 +10,15 @@ use super::{VarValue, UnifyKey, UnifyValue};
 #[allow(type_alias_bounds)]
 type Key<S: UnificationStore> = <S as UnificationStore>::Key;
 
-pub trait Measurable {
-    fn len(&self) -> usize;
-}
-
 /// Largely internal trait implemented by the unification table
 /// backing store types. The most common such type is `InPlace`,
 /// which indicates a standard, mutable unification table.
 pub trait UnificationStore:
-    ops::Index<usize, Output = VarValue<Key<Self>>> + Measurable + Clone + Default
+    ops::Index<usize, Output = VarValue<Key<Self>>> + Clone + Default
 {
     type Key: UnifyKey<Value = Self::Value>;
     type Value: UnifyValue;
-    type Snapshot: Measurable;
+    type Snapshot;
 
     fn start_snapshot(&mut self) -> Self::Snapshot;
 
@@ -30,14 +26,14 @@ pub trait UnificationStore:
 
     fn commit(&mut self, snapshot: Self::Snapshot);
 
-    fn values_since_snapshot(&self, snapshot: &Self::Snapshot) -> Range<usize> {
-        snapshot.len()..self.len()
-    }
+    fn values_since_snapshot(&self, snapshot: &Self::Snapshot) -> Range<usize>;
 
     fn reset_unifications(
         &mut self,
         value: impl FnMut(u32) -> VarValue<Self::Key>,
     );
+
+    fn len(&self) -> usize;
 
     fn push(&mut self, value: VarValue<Self::Key>);
 
@@ -65,20 +61,6 @@ impl<K: UnifyKey> Default for InPlace<K> {
     }
 }
 
-impl Measurable for sv::Snapshot {
-    #[inline]
-    fn len(&self) -> usize {
-        self.length
-    }
-}
-
-impl<K: UnifyKey> Measurable for InPlace<K> {
-    #[inline]
-    fn len(&self) -> usize {
-        self.values.len()
-    }
-}
-
 impl<K: UnifyKey> UnificationStore for InPlace<K> {
     type Key = K;
     type Value = K::Value;
@@ -100,11 +82,20 @@ impl<K: UnifyKey> UnificationStore for InPlace<K> {
     }
 
     #[inline]
+    fn values_since_snapshot(&self, snapshot: &Self::Snapshot) -> Range<usize> {
+        snapshot.value_count..self.len()
+    }
+
+    #[inline]
     fn reset_unifications(
         &mut self,
         mut value: impl FnMut(u32) -> VarValue<Self::Key>,
     ) {
         self.values.set_all(|i| value(i as u32));
+    }
+
+    fn len(&self) -> usize {
+        self.values.len()
     }
 
     #[inline]
@@ -159,14 +150,6 @@ impl<K: UnifyKey> Default for Persistent<K> {
 }
 
 #[cfg(feature = "persistent")]
-impl<K: UnifyKey> Measurable for Persistent<K> {
-    #[inline]
-    fn len(&self) -> usize {
-        self.values.len()
-    }
-}
-
-#[cfg(feature = "persistent")]
 impl<K: UnifyKey> UnificationStore for Persistent<K> {
     type Key = K;
     type Value = K::Value;
@@ -183,7 +166,11 @@ impl<K: UnifyKey> UnificationStore for Persistent<K> {
     }
 
     #[inline]
-    fn commit(&mut self, _snapshot: Self::Snapshot) {
+    fn commit(&mut self, _snapshot: Self::Snapshot) {}
+
+    #[inline]
+    fn values_since_snapshot(&self, snapshot: &Self::Snapshot) -> Range<usize> {
+        snapshot.len()..self.len()
     }
 
     #[inline]
@@ -197,6 +184,10 @@ impl<K: UnifyKey> UnificationStore for Persistent<K> {
         for i in 0 .. self.values.len() {
             self.values[i] = value(i as u32);
         }
+    }
+
+    fn len(&self) -> usize {
+        self.values.len()
     }
 
     #[inline]

--- a/src/unify/mod.rs
+++ b/src/unify/mod.rs
@@ -33,6 +33,7 @@
 
 use std::marker;
 use std::fmt::Debug;
+use std::ops::Range;
 
 mod backing_vec;
 pub use self::backing_vec::{InPlace, UnificationStore};
@@ -297,6 +298,15 @@ impl<S: UnificationStore> UnificationTable<S> {
     /// Returns the number of keys created so far.
     pub fn len(&self) -> usize {
         self.values.len()
+    }
+
+    /// Returns the keys of all variables created since the `snapshot`.
+    pub fn vars_since_snapshot(
+        &self,
+        snapshot: &Snapshot<S>,
+    ) -> Range<S::Key> {
+        let range = self.values.values_since_snapshot(&snapshot.snapshot);
+        S::Key::from_index(range.start as u32)..S::Key::from_index(range.end as u32)
     }
 
     /// Obtains the current value for a particular key.


### PR DESCRIPTION
Follow up to https://github.com/rust-lang-nursery/ena/pull/19.

Adds `UnificationTable::vars_since_snapshot`, making `UnificationStore::values_since_snapshot` accessible publicly.

Also do a little refactoring to clean things up.

These changes are necessary for refactoring in rustc. Apologies for not making these changes at the same time: I didn't previously test the new version of ena in rustc. I've integrated these changes in a local branch of rustc, so this should be the last change.